### PR TITLE
change favicon domain url to dewey-server.azurewebsites.net

### DIFF
--- a/partials/main.tpl.html
+++ b/partials/main.tpl.html
@@ -88,7 +88,7 @@
 
           <div class="details">
 
-            <img class="favicon" ng-src="http://www.google.com/s2/favicons?domain={{getBokmarkUrlDomain(bookmark)}}" alt="{{getBokmarkUrlDomain(bookmark)}}" crossOrigin="anonymous" />
+            <img class="favicon" ng-src="http://dewey-server.azurewebsites.net/favicon?query={{getBokmarkUrlDomain(bookmark)}}" alt="{{getBokmarkUrlDomain(bookmark)}}" crossOrigin="anonymous" />
             <h2>{{bookmark.title}}</h2>
 
             <div class="tag-links">


### PR DESCRIPTION
Hey guy,
haven't succeeded with favicon problem. So I've implemented a small nodejs  application "dewey-server" which hosted on my Azure portal by url http://dewey-server.azurewebsites.net/favicon?query=www.fb.com
and pointed deweyapp to send url and get favicon back from there.

@outcoldman @jamiewilson could you please check it when you have a time. I've called it dewey-server (maybe in a future we will need some more api). Also maybe I need to link this repository to dewey organization.

P.S. as always any comments are welcome.