### PR TITLE
implement export bookmarks to json file from settings window

### DIFF
--- a/js/directives/_module.js
+++ b/js/directives/_module.js
@@ -1,9 +1,10 @@
 define(
 [
 'angular',
-'./updateBackground'
+'./updateBackground',
+'./exportBookmark'
 ],
-function(angular, updateBackgroundFactory) { 'use strict';
+function(angular, updateBackgroundFactory, exportBookmarkFactory) { 'use strict';
 
 // Creates `dewey.directives` module
 var module = angular.module('dewey.directives', []);
@@ -11,4 +12,6 @@ var module = angular.module('dewey.directives', []);
 // Register update background directive
 module.directive('myUpdateBackground', updateBackgroundFactory);
 
+// Register export bookmark directive
+module.directive('exportBookmark', exportBookmarkFactory);
 });

--- a/js/directives/exportBookmark.js
+++ b/js/directives/exportBookmark.js
@@ -1,0 +1,36 @@
+define(
+[
+    'underscore'
+],
+function(_) { 'use strict';
+
+var exportBookmarkFactory = function(bookmarksStorage) {
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {},
+        templateUrl: '/partials/exportBookmark.tpl.html',
+        link: function ($scope, $element) {
+            $element.find('.action-button').on('click', function () {
+
+                bookmarksStorage.getAll(function(bookmarks, setttings) {
+
+                    var toJSON = angular.toJson(bookmarks);
+                    var blob = new Blob([toJSON], { type:"application/json;charset=utf-8;" });     
+                    
+                    var downloadLink = angular.element('<a></a>');
+                    downloadLink.attr('href',window.URL.createObjectURL(blob));
+                    downloadLink.attr('download', 'deweyapp.json');
+                    downloadLink[0].click();
+                });                
+            });
+        }
+    };
+};
+
+return [
+    'bookmarksStorage',
+    exportBookmarkFactory
+];
+
+});

--- a/partials/exportBookmark.tpl.html
+++ b/partials/exportBookmark.tpl.html
@@ -1,0 +1,1 @@
+<div class="credits"><p><a class="important action-button" style="cursor: pointer;">Export</a></p></div>

--- a/partials/main.tpl.html
+++ b/partials/main.tpl.html
@@ -43,6 +43,7 @@
               <input id="hide-folders" class="css-checkbox" type="checkbox" ng-checked="hideTopLevelFolders" />
               <label for="hide-folders" class="css-label">Hide Top-level Folders as Tags</label>
             </div>
+            <export-bookmark></export-bookmark>
             <div class="credits"><p>Screenshots by <a class="important" href="http://www.page2images.com/" target="_blank">Page2Images</a></p></div>
           </form>
         </li>


### PR DESCRIPTION
Hey guys,
I've started with export/import functionality. I've added an export link to the settings window. @jamiewilson probably we should change UI here. `exportBookmark.tmp.html` contains all html for this link. Probably somewhere here should be an import link too.

@outcoldman for now I'm just saving `bookmarksStorage.getAll` function result as json file. What do you think about this? Chrome saves everything as html file. Would it be better for us to do the same with small modification?
P.S. it's just an init commit for discussion.