### PR TITLE
Removing img elements if error or disabled

### DIFF
--- a/js/directives/updateBackground.js
+++ b/js/directives/updateBackground.js
@@ -43,21 +43,22 @@ var myUpdateBackgroundFactory = function(appSettings, $http) {
 
     return function(scope, element, attrs) {
         scope.$watch(attrs.dLoad, function(value) {
+            var thumbnail = element.find('img');
             if (appSettings.showThumbnails) {
                 // Get url without search or hash, so we will be able to cache
                 var requestedUrl = scope.bookmark.url;
                 var url = 'https://deweyapp.com/screenshot/' + encodeURIComponent(requestedUrl) + '/screenshot.png';
-                var thumbnail = element.find('img');
                 thumbnail
                 .prop('src', url)
                 .on('load', function() {
                     updateThumbnailColor(element, [255, 255, 255]);
                 })
                 .on('error', function() {
-                    thumbnail.hide();
+                    thumbnail.remove();
                     updateThumbnailColor(element);
                 });
             } else {
+                thumbnail.remove();
                 updateThumbnailColor(element);
             }
         });


### PR DESCRIPTION
I noticed that when screenshots were disabled, the `img` elements were still there, just without a `src` attribute. Rather than hiding these, I thought it made sense just to remove them altogether.

Let me know if you'd like me to revise for any reason. Thanks!