### PR TITLE
[Issue#36] Auto-block Backspace when end of text in Tags

### DIFF
--- a/js/lib/bootstrap-tagsinput-angular.js
+++ b/js/lib/bootstrap-tagsinput-angular.js
@@ -46,6 +46,15 @@ angular.module('bootstrap-tagsinput', [])
             scope.model.push(event.item);
         });
 
+        //When the tagsinput input is empty, restrict the backspace, 
+        //otherwise this deletes other existing tags. 
+        select.tagsinput('input').on('keydown', function(event){
+          if($(this).val().length == 0 && event.keyCode == 8){
+            event.preventDefault();
+            return false;
+          }
+        });
+
         select.on('itemRemoved', function(event) {
           var idx = scope.model.indexOf(event.item);
           if (idx !== -1)


### PR DESCRIPTION
 - Added check on bootstrap tagsinput to prevent default when the input is empty and the key is backspace.

See link to original issue: https://github.com/deweyapp/dewey/issues/36
